### PR TITLE
Re-include Python 3.10 support to pass CI

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,11 +7,11 @@ authors = [
 ]
 license = {text = "GPL-3.0-or-later"}
 readme = "README.md"
-requires-python = ">=3.11, <3.13"
+requires-python = ">=3.10, <3.13"
 dependencies = [
     "numpy (>=1.26.4,<2.0.0)",
     "scipy (>=1.15.3,<1.16.0)",
-    "astropy (>=7.1.0,<8.0.0)",
+    "astropy (>=6.1.7,<8.0.0)",
     "matplotlib (>=3.10.1,<3.11.0)",
     "pyyaml (>=6.0.2,<7.0.0)",
 
@@ -35,7 +35,7 @@ pytest-cov = "^6.1.1"
 optional = true
 
 [tool.poetry.group.docs.dependencies]
-sphinx = "^8.2.3"
+sphinx = "^8.1.3"
 sphinx-book-theme = "^1.1.3"
 sphinx-copybutton = "^0.5.2"
 sphinxcontrib-apidoc = ">=0.6.0"


### PR DESCRIPTION
The 3.10 matrix combination is now actually failing (as it should have done the whole time), because the DevOps still defines 3.10.

Had to downgrade astropy and sphinx to support this, but whatever.