### PR TITLE
Add basic support for spectrum from file

### DIFF
--- a/scopesim_targets/target.py
+++ b/scopesim_targets/target.py
@@ -89,7 +89,8 @@ class SpectrumTarget(Target):
                 # TODO: Consider adding check at this point if spex exists
                 self._spectrum = spex
             case str(file) if file.startswith("file:"):
-                raise NotImplementedError("Spectrum from file not yet supported.")
+                # TODO: Consider adding check if file exists already here
+                self._spectrum = file
             case str() | SpectralType():
                 self._spectrum = SpectralType(spectrum)
             case _:
@@ -112,6 +113,11 @@ class SpectrumTarget(Target):
         if isinstance(self.spectrum, str) and self.spectrum.startswith("spex:"):
             # Explicit SpeXtra identifier
             return Spextrum(self.spectrum.removeprefix("spex:"))
+
+        if isinstance(self.spectrum, str) and self.spectrum.startswith("file:"):
+            # Explicit SpeXtra identifier
+            # TODO: Use pathlib file URI here
+            return SourceSpectrum.from_file(self.spectrum.removeprefix("file:"))
 
         # HACK: The current DEFAULT_LIBRARY stores spectral classes in lowercase
         #       letters, while SpectralType converts to uppercase. This needs a

--- a/tests/test_target.py
+++ b/tests/test_target.py
@@ -87,9 +87,11 @@ class TestSpectrumTarget:
         with pytest.raises((ValueError, TypeError)):
             spectrum_target_subcls.spectrum = spectrum
 
-    def test_spectrum_throws_file(self, spectrum_target_subcls):
-        with pytest.raises(NotImplementedError):
-            spectrum_target_subcls.spectrum = "file:bogus"
+    def test_spectrum_from_file(self, spectrum_target_subcls):
+        # TODO: Add actual test with mock file
+        spectrum_target_subcls.spectrum = "file:bogus"
+        with pytest.raises(FileNotFoundError):
+            spectrum_target_subcls.resolve_spectrum()
 
     # @pytest.mark.webtest
     def test_resolves_spectrum(self, spectrum_target_subcls):


### PR DESCRIPTION
Currently only wraps `synphot.SourceSpectrum.from_file()`, so only supports whatever that one supports. Still closes #41 for now.