### PR TITLE
Make more example yamls pass tests

### DIFF
--- a/docs/example_yamls/exoplanetary/planets1.yaml
+++ b/docs/example_yamls/exoplanetary/planets1.yaml
@@ -8,7 +8,7 @@ primary:
   !Binary
   offset:
     separation: .1 AU
-  spectra: [G0V, M5V]
+  spectra: [G0V, M2V]
   brightness: ["R", 15 mag]  # Primary
   contrast: 1.0e+2
 components:

--- a/tests/test_example_yamls.py
+++ b/tests/test_example_yamls.py
@@ -5,6 +5,7 @@ from pathlib import Path
 
 import pytest
 import yaml
+from astropy import units as u
 
 from scopesim_targets.target import Target
 
@@ -27,8 +28,12 @@ def test_examle_yamls_parse(subtests):
 
 @pytest.mark.xfail
 def test_examle_yamls_can_make_source(subtests):
+    opt_dict = {"pixel_scale": 0.1*u.arcsec/u.pix, "width": 200, "height": 100}
     for file in EXAMPLE_YAML_PATH.rglob("*.yaml"):
         with subtests.test(filename=file.name):
             with file.open("r", encoding="utf-8") as stream:
                 tgt = yaml.full_load(stream)
-            tgt.to_source()
+            if isinstance(tgt, ParametrizedTarget):
+                tgt.to_source(opt_dict)
+            else:
+                tgt.to_source()


### PR DESCRIPTION
Something of a workaround to solve two issues that made some example yamls xfail in the source conversion tests:
- "M2V" isn't in default spectral library (see #68).
- Parametrized targets need "optical train dict" for pixel scale etc, but other subclasses can't handle that yet.
(see #72)