### PR TITLE
Cleanup target registering and TODOs

### DIFF
--- a/scopesim_targets/__init__.py
+++ b/scopesim_targets/__init__.py
@@ -2,10 +2,24 @@
 """Importing this package has the side-effect of adding custom YAML tags."""
 
 from .target import Target
+from . import point_source
+from . import extended_source
 
-from .yaml_constructors import register_qty, register_coord
-
+from .yaml_constructors import (
+    register_qty,
+    register_coord,
+    register_target_constructor,
+)
 
 # Run YAML registrations
 register_qty()
 register_coord()
+
+register_target_constructor(point_source.Star)
+register_target_constructor(point_source.Binary)
+register_target_constructor(point_source.Exoplanet)
+register_target_constructor(point_source.PlanetarySystem)
+register_target_constructor(point_source.StarField)
+
+register_target_constructor(extended_source.Sersic)
+register_target_constructor(extended_source.Disk)

--- a/scopesim_targets/extended_source.py
+++ b/scopesim_targets/extended_source.py
@@ -15,7 +15,6 @@ from scopesim import Source
 from scopesim.source.source_fields import ImageSourceField
 
 from .typing_utils import POSITION_TYPE, SPECTRUM_TYPE, BRIGHTNESS_TYPE
-from .yaml_constructors import register_target_constructor
 from .target import SpectrumTarget
 
 
@@ -133,7 +132,3 @@ class Disk(ParametrizedTarget):
             self._model.bounding_box = None  # TODO: Revisit this
         else:
             raise ValueError("radius and width are currently required")
-
-
-register_target_constructor(Sersic)
-register_target_constructor(Disk)

--- a/scopesim_targets/point_source.py
+++ b/scopesim_targets/point_source.py
@@ -17,7 +17,6 @@ from scopesim import Source
 from scopesim.source.source_fields import TableSourceField
 
 from .typing_utils import POSITION_TYPE, SPECTRUM_TYPE, BRIGHTNESS_TYPE
-from .yaml_constructors import register_target_constructor
 from .target import Brightness, SpectrumTarget
 
 
@@ -553,11 +552,3 @@ class StarField(PointSourceTarget):
         table.meta["y_unit"] = "arcsec"
 
         return Source(field=TableSourceField(table, spectra=resolved_spectra))
-
-
-# TODO: Move these to __init__.py?
-register_target_constructor(Star)
-register_target_constructor(Binary)
-register_target_constructor(Exoplanet)
-register_target_constructor(PlanetarySystem)
-register_target_constructor(StarField)

--- a/scopesim_targets/point_source.py
+++ b/scopesim_targets/point_source.py
@@ -5,6 +5,7 @@ from collections.abc import Sequence, Mapping
 from itertools import count
 from numbers import Number  # matches int, float and all the numpy scalars
 
+from more_itertools import unzip
 from astropy import units as u
 from astropy.table import Table
 from astropy.coordinates import SkyCoord
@@ -117,6 +118,9 @@ class Star(PointSourceTarget):
 class Binary(PointSourceTarget):
     """Binary star.
 
+    .. todo:: Fix offset definition via distance and physical separation, see
+        :issue:`107` (also applies to other target subclasses).
+
     Examples
     --------
     >>> tgt = Binary(
@@ -206,14 +210,15 @@ class Binary(PointSourceTarget):
 
         Brightness of the secondary can also be specified via the
         `brightness_secondary` attribute instead, which supports magnitudes.
+
+        .. todo:: Add support for dimensionless Quantity and other numerical
+            types in setter type check.
         """
         return self._contrast
 
     @contrast.setter
     def contrast(self, contrast: float):
         if not isinstance(contrast, float):
-            # TODO: Also check for dimensionless Quantity here, and also numpy
-            #       float-ish types. Int should also be fine...
             raise TypeError("contrast must be float or dimensionless Quantity")
         self._contrast = contrast
 
@@ -421,6 +426,9 @@ class PlanetarySystem(PointSourceTarget):
 class StarField(PointSourceTarget):
     """Multiple Stars.
 
+    .. todo:: Add support for defining a common (field center) position to which
+        the individual positions are interpreted als relative to.
+
     Examples
     --------
     >>> tgt = StarField(
@@ -508,14 +516,12 @@ class StarField(PointSourceTarget):
 
     def to_source(self) -> Source:
         """Convert to ScopeSim Source object."""
-        # TODO: Consider top-level center coords (somehow...)
         local_frame = SkyCoord(0*u.deg, 0*u.deg).skyoffset_frame()
 
         xy_positions = []
         for position in self.positions:
             xy_positions.append(self._xy_arcsec_position(position, local_frame))
 
-        from more_itertools import unzip
         x_positions, y_positions = unzip(xy_positions)
 
         spectra_ids = dict(zip(set(self.spectra), count()))

--- a/tests/test_example_yamls.py
+++ b/tests/test_example_yamls.py
@@ -8,11 +8,7 @@ import yaml
 from astropy import units as u
 
 from scopesim_targets.target import Target
-
-# HACK: Temporary to ensue proper import and yaml tag registring
-from scopesim_targets.point_source import *
-from scopesim_targets.extended_source import *
-
+from scopesim_targets.extended_source import ParametrizedTarget
 
 EXAMPLE_YAML_PATH = Path(__package__).parent / "docs"
 


### PR DESCRIPTION
Allows to use YAML constructors for target subclasses without having to import the right module before.
TODOs in docstrings become visible on RTD, which is useful for some cases.