### PR TITLE
Clone IRDB into RTD build, update RTD versions

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -24,6 +24,7 @@ build:
       # VIRTUAL_ENV needs to be set manually for now.
       # See https://github.com/readthedocs/readthedocs.org/pull/11152/
       - VIRTUAL_ENV=$READTHEDOCS_VIRTUALENV_PATH poetry install --with docs --all-extras
+      - VIRTUAL_ENV=$READTHEDOCS_VIRTUALENV_PATH poetry run pip install git+https://github.com/AstarVienna/ScopeSim_Data.git
 
 sphinx:
   configuration: docs/conf.py

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -5,10 +5,15 @@
 version: 2
 
 build:
-  os: "ubuntu-22.04"
+  os: "ubuntu-24.04"
   tools:
-    python: "3.11"
+    python: "3.13"
   jobs:
+    post_checkout:
+      - git clone -n --depth=1 --filter=tree:0 https://github.com/AstarVienna/irdb ./docs/inst_pkgs
+      - git -C ./docs/inst_pkgs sparse-checkout set --no-cone Armazones ELT MICADO !docs
+      - git -C ./docs/inst_pkgs checkout
+      - find . -name \*.ipynb -type f -print
     post_create_environment:
       # Install poetry
       # https://python-poetry.org/docs/#installing-manually


### PR DESCRIPTION
As is done in ScopeSim, avoids downloading the IRDB during the docs execution.

Spectra are still downloaded, this should be fixed in SpeXtra (and ScopeSim_Data, see AstarVienna/ScopeSim_Data#32).