### PR TITLE
Include abs. mag and mass in cluster table

### DIFF
--- a/scopesim_targets/cluster.py
+++ b/scopesim_targets/cluster.py
@@ -68,7 +68,7 @@ class ZeroAgeCluster(Cluster):
 
         tbl = Table(
             data=src_coldict,
-            names=["x", "y", "ref", "weight"],
+            names=["x", "y", "ref", "weight", "absmag", "mass"],
             units={"x": u.arcsec, "y": u.arcsec},
         )
         return Source(field=TableSourceField(tbl, spectra=spectra))

--- a/scopesim_targets/stellar/populations.py
+++ b/scopesim_targets/stellar/populations.py
@@ -168,7 +168,13 @@ class IMFPopulation(ZeroAgePopulation):
         delta_mag = distmod + absmags - specmags
         weights = (delta_mag.value * delta_mag.unit()).physical
 
-        return {"ref": specref, "weight": weights}, spectra
+        coldict = {
+            "ref": specref,
+            "weight": weights,
+            "absmag": absmags,
+            "mass": masses,
+        }
+        return coldict, spectra
 
     def plot(
         self,


### PR DESCRIPTION
While not needed or used by the Source object, this is very useful when performing analysis on the output image.